### PR TITLE
do not require authentication to get help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.log
+*.log.*
 *.pyc
 *.swp
 *~

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Dean Troyer <dtroyer@gmail.com>
+Doug Hellmann <doug.hellmann@dreamhost.com>

--- a/openstackclient/common/command.py
+++ b/openstackclient/common/command.py
@@ -26,6 +26,14 @@ class OpenStackCommand(Command):
     """Base class for OpenStack commands
     """
 
+    # Boolean indicating whether this command needs the user to
+    # provide authentication information before it can be run. The
+    # value is used by OpenStackShell.get_token_and_endpoint() to
+    # decide if the user needs to provide those options before the
+    # command is attempted. Most commands need auth, but we need
+    # a way to let the `help` command run without it.
+    REQUIRES_AUTH = True
+
     api = None
 
     def run(self, parsed_args):

--- a/openstackclient/shell.py
+++ b/openstackclient/shell.py
@@ -19,7 +19,6 @@
 Command-line interface to the OpenStack APIs
 """
 
-import argparse
 import logging
 import os
 import sys

--- a/openstackclient/shell.py
+++ b/openstackclient/shell.py
@@ -124,6 +124,9 @@ class OpenStackShell(App):
         the user has not and the command requires it. If the command
         does not require authentication, returns (None, None).
         """
+        requires_auth = getattr(cmd, 'REQUIRES_AUTH', False)
+        if not requires_auth:
+            return (None, None)
 
         # do checking of os_username, etc here
         if (self.options.os_token and self.options.os_url):


### PR DESCRIPTION
Allow some commands, especially "help," to run without the authentication options set.
